### PR TITLE
Update gh actions; Add Django 4.1, Python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -25,7 +25,7 @@ jobs:
         echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
 
     - name: Cache
       uses: actions/cache@v3

--- a/knox_project/settings.py
+++ b/knox_project/settings.py
@@ -49,7 +49,7 @@ DATABASES = {
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True
+USE_L10N = True  # Deprecated since django 4.0.
 USE_TZ = True
 
 STATIC_URL = '/static/'

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
 
     # What does your project relate to?

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
     django41: Django>=4.1.3,<4.2
-    markdown<3.0
+    markdown>=3.0
     isort>=5.0
     djangorestframework
     freezegun

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     flake8,
     py{36,37,38,39,310}-django32,
     py{38,39,310}-django40,
-    py{38,39,310}-django41,
+    py{38,39,310,311}-django41,
 
 [testenv:flake8]
 deps = flake8
@@ -30,7 +30,7 @@ setenv =
 deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
-    django41: Django>=4.1,<4.2
+    django41: Django>=4.1.3,<4.2
     markdown<3.0
     isort>=5.0
     djangorestframework
@@ -48,3 +48,4 @@ python =
     3.8: py38
     3.9: py39, isort, flake8
     3.10: py310
+    3.11: py311

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     flake8,
     py{36,37,38,39,310}-django32,
     py{38,39,310}-django40,
+    py{38,39,310}-django41,
 
 [testenv:flake8]
 deps = flake8
@@ -29,6 +30,7 @@ setenv =
 deps =
     django32: Django>=3.2,<3.3
     django40: Django>=4.0,<4.1
+    django41: Django>=4.1,<4.2
     markdown<3.0
     isort>=5.0
     djangorestframework

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,6 @@ python =
     3.6: py36
     3.7: py37
     3.8: py38
-    3.9: py39, isort, flake8
-    3.10: py310
+    3.9: py39
+    3.10: py310, isort, flake8
     3.11: py311


### PR DESCRIPTION
## Add

* Django 4.1 has been released! https://docs.djangoproject.com/en/4.1/releases/4.1/
* Python 3.11 has been released!

## Update

* GitHub Actions: Deprecating save-state and set-output commands https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
*  Bump GH Actions versions 