### PR TITLE
Remove legacy code from Python 2

### DIFF
--- a/knox/auth.py
+++ b/knox/auth.py
@@ -1,10 +1,5 @@
-try:
-    from hmac import compare_digest
-except ImportError:
-    def compare_digest(a, b):
-        return a == b
-
 import binascii
+from hmac import compare_digest
 
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,5 +1,6 @@
 import base64
 from datetime import datetime, timedelta
+from importlib import reload
 
 from django.contrib.auth import get_user_model
 from django.test import override_settings
@@ -8,7 +9,6 @@ from freezegun import freeze_time
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.serializers import DateTimeField
 from rest_framework.test import APIRequestFactory, APITestCase as TestCase
-from six.moves import reload_module
 
 from knox import auth, crypto, views
 from knox.auth import TokenAuthentication
@@ -93,7 +93,7 @@ class AuthTestCase(TestCase):
     def test_login_returns_serialized_token_and_username_field(self):
 
         with override_settings(REST_KNOX=user_serializer_knox):
-            reload_module(views)
+            reload(views)
             self.assertEqual(AuthToken.objects.count(), 0)
             url = reverse('knox_login')
             self.client.credentials(
@@ -101,7 +101,7 @@ class AuthTestCase(TestCase):
             )
             response = self.client.post(url, {}, format='json')
             self.assertEqual(user_serializer_knox["USER_SERIALIZER"], UserSerializer)
-        reload_module(views)
+        (views)
         self.assertEqual(response.status_code, 200)
         self.assertIn('token', response.data)
         username_field = self.user.USERNAME_FIELD
@@ -111,7 +111,7 @@ class AuthTestCase(TestCase):
     def test_login_returns_configured_expiry_datetime_format(self):
 
         with override_settings(REST_KNOX=expiry_datetime_format_knox):
-            reload_module(views)
+            reload(views)
             self.assertEqual(AuthToken.objects.count(), 0)
             url = reverse('knox_login')
             self.client.credentials(
@@ -122,7 +122,7 @@ class AuthTestCase(TestCase):
                 expiry_datetime_format_knox["EXPIRY_DATETIME_FORMAT"],
                 EXPIRY_DATETIME_FORMAT
             )
-        reload_module(views)
+        reload(views)
         self.assertEqual(response.status_code, 200)
         self.assertIn('token', response.data)
         self.assertNotIn('user', response.data)
@@ -257,10 +257,10 @@ class AuthTestCase(TestCase):
         self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % token))
         five_hours_later = original_time + timedelta(hours=5)
         with override_settings(REST_KNOX=auto_refresh_knox):
-            reload_module(auth)  # necessary to reload settings in core code
+            reload(auth)  # necessary to reload settings in core code
             with freeze_time(five_hours_later):
                 response = self.client.get(root_url, {}, format='json')
-        reload_module(auth)
+        reload(auth)
         self.assertEqual(response.status_code, 200)
 
         # original expiry date was extended:
@@ -309,10 +309,10 @@ class AuthTestCase(TestCase):
         self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % token))
         in_min_interval = now + timedelta(seconds=knox_settings.MIN_REFRESH_INTERVAL - 10)
         with override_settings(REST_KNOX=auto_refresh_knox):
-            reload_module(auth)  # necessary to reload settings in core code
+            reload(auth)  # necessary to reload settings in core code
             with freeze_time(in_min_interval):
                 response = self.client.get(root_url, {}, format='json')
-        reload_module(auth)  # necessary to reload settings in core code
+        reload(auth)  # necessary to reload settings in core code
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(original_expiry, AuthToken.objects.get().expiry)
@@ -334,7 +334,7 @@ class AuthTestCase(TestCase):
     def test_exceed_token_amount_per_user(self):
 
         with override_settings(REST_KNOX=token_user_limit_knox):
-            reload_module(views)
+            reload(views)
             for _ in range(10):
                 AuthToken.objects.create(user=self.user)
             url = reverse('knox_login')
@@ -342,7 +342,7 @@ class AuthTestCase(TestCase):
                 HTTP_AUTHORIZATION=get_basic_auth_header(self.username, self.password)
             )
             response = self.client.post(url, {}, format='json')
-        reload_module(views)
+        reload(views)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.data,
                          {"error": "Maximum amount of tokens allowed per user exceeded."})
@@ -350,7 +350,7 @@ class AuthTestCase(TestCase):
     def test_does_not_exceed_on_expired_keys(self):
 
         with override_settings(REST_KNOX=token_user_limit_knox):
-            reload_module(views)
+            reload(views)
             for _ in range(9):
                 AuthToken.objects.create(user=self.user)
             AuthToken.objects.create(user=self.user, expiry=timedelta(seconds=-1))
@@ -361,7 +361,7 @@ class AuthTestCase(TestCase):
             )
             response = self.client.post(url, {}, format='json')
             failed_response = self.client.post(url, {}, format='json')
-        reload_module(views)
+        reload(views)
         self.assertEqual(response.status_code, 200)
         self.assertIn('token', response.data)
         self.assertEqual(failed_response.status_code, 403)
@@ -371,7 +371,7 @@ class AuthTestCase(TestCase):
     def test_invalid_prefix_return_401(self):
 
         with override_settings(REST_KNOX=auth_header_prefix_knox):
-            reload_module(auth)
+            reload(auth)
             instance, token = AuthToken.objects.create(user=self.user)
             self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % token))
             failed_response = self.client.get(root_url)
@@ -381,13 +381,13 @@ class AuthTestCase(TestCase):
                 )
             )
             response = self.client.get(root_url)
-        reload_module(auth)
+        reload(auth)
         self.assertEqual(failed_response.status_code, 401)
         self.assertEqual(response.status_code, 200)
 
     def test_expiry_present_also_when_none(self):
         with override_settings(REST_KNOX=token_no_expiration_knox):
-            reload_module(views)
+            reload(views)
             self.assertEqual(AuthToken.objects.count(), 0)
             url = reverse('knox_login')
             self.client.credentials(
@@ -406,7 +406,7 @@ class AuthTestCase(TestCase):
                 response.data['expiry'],
                 None
             )
-        reload_module(views)
+        reload(views)
 
     def test_expiry_is_present(self):
         self.assertEqual(AuthToken.objects.count(), 0)
@@ -429,8 +429,8 @@ class AuthTestCase(TestCase):
 
     def test_login_returns_serialized_token_with_prefix_when_prefix_set(self):
         with override_settings(REST_KNOX=token_prefix_knox):
-            reload_module(views)
-            reload_module(crypto)
+            reload(views)
+            reload(crypto)
             self.assertEqual(AuthToken.objects.count(), 0)
             url = reverse('knox_login')
             self.client.credentials(
@@ -443,12 +443,12 @@ class AuthTestCase(TestCase):
             )
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.data['token'].startswith(token_prefix))
-        reload_module(views)
-        reload_module(crypto)
+        reload(views)
+        reload(crypto)
 
     def test_token_with_prefix_returns_200(self):
         with override_settings(REST_KNOX=token_prefix_knox):
-            reload_module(views)
+            reload(views)
             self.assertEqual(AuthToken.objects.count(), 0)
             url = reverse('knox_login')
             self.client.credentials(
@@ -464,7 +464,7 @@ class AuthTestCase(TestCase):
             self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % response.data['token']))
             response = self.client.get(root_url, {}, format='json')
             self.assertEqual(response.status_code, 200)
-        reload_module(views)
+        reload(views)
 
     def test_prefix_set_longer_than_max_length_raises_valueerror(self):
         with self.assertRaises(ValueError):    
@@ -483,8 +483,8 @@ class AuthTestCase(TestCase):
         )
         self.assertFalse(response.data['token'].startswith(token_prefix))
         with override_settings(REST_KNOX=token_prefix_knox):
-            reload_module(views)
+            reload(views)
             self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % response.data['token']))
             response = self.client.get(root_url, {}, format='json')
             self.assertEqual(response.status_code, 200)
-        reload_module(views)
+        reload(views)


### PR DESCRIPTION
Not needed with Python 3 because it is default lib.