### PR TITLE
Enable customizing login/logout responses

### DIFF
--- a/docs/views.md
+++ b/docs/views.md
@@ -67,12 +67,24 @@ It responds to Knox Token Authentication. On a successful request,
 the token used to authenticate is deleted from the
 system and can no longer be used to authenticate.
 
+By default, this endpoint returns a HTTP 204 response on a successful request. To
+customize this behavior, you can override the `get_post_response` method, for example
+to include a body in the logout response and/or to modify the status code:
+
+```python
+...snip...
+    def get_post_response(self, request):
+        return Response({"bye-bye": request.user.username}, status=200)
+...snip...
+```
+
 ## LogoutAllView
 This view accepts only a post request with an empty body. It responds to Knox Token
 Authentication.
-On a successful request, the token used to authenticate, and *all other tokens*
-registered to the same `User` account, are deleted from the
-system and can no longer be used to authenticate.
+On a successful request, a HTTP 204 is returned and the token used to authenticate,
+and *all other tokens* registered to the same `User` account, are deleted from the
+system and can no longer be used to authenticate. The success response can be modified
+like the `LogoutView` by overriding the `get_post_response` method.
 
 **Note** It is not recommended to alter the Logout views. They are designed
 specifically for token management, and to respond to Knox authentication.


### PR DESCRIPTION
This pull request is a small change to enable customizing the response shape for the login and logout views by overriding a simple method.

This is useful in situations where for example the 204 responses in the logout views are undesirable (e.g. for clients that always assume that responses have a JSON body).