### PR TITLE
test: Set up pre-commit hooks and fix quality nits

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default: false
+      tests:
+        paths: tests
+        informational: true
+      knox:
+        paths: knox
+        informational: true
+    patch: off

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+source = knox
+omit =
+    */migrations/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
+        python -m pip install --upgrade tox tox-gh-actions coverage
 
     - name: Tox tests
       run: |
         tox -v
+
+    - name: Generate coverage XML report
+      run: coverage xml
+
+    - name: Codecov
+      uses: codecov/codecov-action@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.11.5
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -53,6 +53,7 @@ token_prefix_too_long = "a" * CONSTANTS.MAXIMUM_TOKEN_PREFIX_LENGTH + "a"
 token_prefix_too_long_knox = knox_settings.defaults.copy()
 token_prefix_too_long_knox["TOKEN_PREFIX"] = token_prefix_too_long
 
+
 class AuthTestCase(TestCase):
 
     def setUp(self):
@@ -325,7 +326,10 @@ class AuthTestCase(TestCase):
 
         token_expired.connect(handler)
 
-        instance, token = AuthToken.objects.create(user=self.user, expiry=timedelta(seconds=-1))
+        instance, token = AuthToken.objects.create(
+            user=self.user,
+            expiry=timedelta(seconds=-1),
+        )
         self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % token))
         self.client.post(root_url, {}, format='json')
 
@@ -461,13 +465,15 @@ class AuthTestCase(TestCase):
             )
             self.assertEqual(response.status_code, 200)
             self.assertTrue(response.data['token'].startswith(token_prefix))
-            self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % response.data['token']))
+            self.client.credentials(
+                HTTP_AUTHORIZATION=('Token %s' % response.data['token'])
+            )
             response = self.client.get(root_url, {}, format='json')
             self.assertEqual(response.status_code, 200)
         reload_module(views)
 
     def test_prefix_set_longer_than_max_length_raises_valueerror(self):
-        with self.assertRaises(ValueError):    
+        with self.assertRaises(ValueError):
             with override_settings(REST_KNOX=token_prefix_too_long_knox):
                 pass
 
@@ -484,7 +490,9 @@ class AuthTestCase(TestCase):
         self.assertFalse(response.data['token'].startswith(token_prefix))
         with override_settings(REST_KNOX=token_prefix_knox):
             reload_module(views)
-            self.client.credentials(HTTP_AUTHORIZATION=('Token %s' % response.data['token']))
+            self.client.credentials(
+                HTTP_AUTHORIZATION=('Token %s' % response.data['token'])
+            )
             response = self.client.get(root_url, {}, format='json')
             self.assertEqual(response.status_code, 200)
         reload_module(views)

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,8 @@ commands = isort --check-only --diff \
 [testenv]
 commands =
     python manage.py migrate
-    python manage.py test
+    coverage run manage.py test
+    coverage report
 setenv =
     DJANGO_SETTINGS_MODULE = knox_project.settings
     PIP_INDEX_URL = https://pypi.python.org/simple/
@@ -38,6 +39,7 @@ deps =
     setuptools
     twine
     wheel
+    coverage
 
 [gh-actions]
 python =


### PR DESCRIPTION
This PR implements:
* A pre-commit hook that runs `isort` and `flake8`
* Code coverage reports and `codecov` WIP