### PR TITLE
Fix migrations when used in condition with a custom DB.

### DIFF
--- a/knox/migrations/0006_auto_20160818_0932.py
+++ b/knox/migrations/0006_auto_20160818_0932.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 
 def cleanup_tokens(apps, schema_editor):
     AuthToken = apps.get_model('knox', 'AuthToken')
-    AuthToken.objects.filter(token_key__isnull=True).delete()
+    AuthToken.objects.using(schema_editor.connection.alias).filter(token_key__isnull=True).delete()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
We have recently picked up Knox to use it within one of our projects that uses custom databases during its testing steps. While our setup isn't the most common. it is supported by Django. Unfortunately when using a custom DB the `0006_auto_20160818_0932.py` fails to run because the ORM call doesn't respect the schemas DB connection.

The fix included here just sets the connection alias to respect that configured by the schema. This doesn't effect anyone using the standard DB and doesn't effect anyone who already has the migration install, however allows users with a custom DB connection to now run the migration.

Thanks for the great package you provide. Please let me know if you require any further clarification.