### PR TITLE
feat(ci): add current django and python to test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
     # What does your project relate to?

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     isort,
     flake8,
     py{36,37,38,39,310}-django32,
-    py{38,39,310,311}-django41,
-    py{38,39,310,311}-django42,
+    py{38,39,310,311,312}-django42,
+    py{310,311,312}-django50,
 
 [testenv:flake8]
 deps = flake8
@@ -30,8 +30,8 @@ setenv =
     PIP_INDEX_URL = https://pypi.python.org/simple/
 deps =
     django32: Django>=3.2,<3.3
-    django41: Django>=4.1.3,<4.2
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
     markdown>=3.0
     isort>=5.0
     djangorestframework

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,8 @@ envlist =
     isort,
     flake8,
     py{36,37,38,39,310}-django32,
-    py{38,39,310}-django40,
     py{38,39,310,311}-django41,
+    py{38,39,310,311}-django42,
 
 [testenv:flake8]
 deps = flake8
@@ -30,8 +30,8 @@ setenv =
     PIP_INDEX_URL = https://pypi.python.org/simple/
 deps =
     django32: Django>=3.2,<3.3
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1.3,<4.2
+    django42: Django>=4.2,<4.3
     markdown>=3.0
     isort>=5.0
     djangorestframework
@@ -49,5 +49,6 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310, isort, flake8
-    3.11: py311
+    3.10: py310
+    3.11: py311, isort, flake8
+    3.12: py312


### PR DESCRIPTION
- Django 4.0 EOL since 01 Apr 2023.
- Django 4.1 EOL since 01 Dec 2023.
- 4.2 is new LTS.
- 5.0 is new current.

https://endoflife.date/django