### PR TITLE
refactor(auth): Use `self.authenticate_header()` in `authenticate()` method to get auth header prefix

### DIFF
--- a/knox/auth.py
+++ b/knox/auth.py
@@ -29,7 +29,7 @@ class TokenAuthentication(BaseAuthentication):
 
     def authenticate(self, request):
         auth = get_authorization_header(request).split()
-        prefix = knox_settings.AUTH_HEADER_PREFIX.encode()
+        prefix = self.authenticate_header(request).encode()
 
         if not auth:
             return None


### PR DESCRIPTION
## Description
As titled, seems like the `TokenAuthentication` class already defined a method to retrieve the header, yet not utilized within the class itself.

ref: the related method
```python
def authenticate_header(self, request):
    return knox_settings.AUTH_HEADER_PREFIX
```

[Similar technique](https://github.com/encode/django-rest-framework/blob/2797c0f216288bd7ca82e9e32e5f7d699bac74df/rest_framework/authentication.py#L180) has been done in `rest_framework` Token Authentication (though, using class attribute)

##  Impact
These changes allows the auth header to be overridden from the subclass without having to override the `authenticate()`  method (just for small auth prefix header changes) or meddling with global settings for `knox_settings.AUTH_HEADER_PREFIX` (because it might be used somewhere else within the project)



## example usage:
```python
class TokenAuthWithCustomHeader(knox.TokenAuthentication):
    def authenticate_header(self, request):
        return "MyCustomAuthPrefix"
```

without these changes, the subclass needs to:
```python

class TokenAuthWithCustomHeader(knox.TokenAuthentication):
    def authenticate(self, request):
        prefix =  "MyCustomAuthPrefix"
        # re-implement the exact same logic
        ...
                 
```
