### PR TITLE
Django Admin integation fix adding AuthToken

### DIFF
--- a/knox/admin.py
+++ b/knox/admin.py
@@ -1,10 +1,49 @@
-from django.contrib import admin
-
+from django import forms
+from django.contrib import admin, messages
+from django.contrib.auth import get_user_model
+from knox.settings import CONSTANTS
 from knox import models
+
+
+class AuthTokenCreateForm(forms.ModelForm):
+
+    def __init__(self, *args, **kwargs):
+        super(AuthTokenCreateForm, self).__init__(*args, **kwargs)
+        self.token = None
+
+    class Meta:
+        model = models.AuthToken
+        fields = ['user', 'expiry']
+
+    def save(self, commit=True):
+        obj = super(AuthTokenCreateForm, self).save(commit=False)
+        digest, token = models.get_digest_token()
+        obj.digest = digest
+        obj.token_key = token[:CONSTANTS.TOKEN_KEY_LENGTH]
+        self.token = token
+        if commit:
+            obj.save()
+            obj.save_m2m()
+        return obj
 
 
 @admin.register(models.AuthToken)
 class AuthTokenAdmin(admin.ModelAdmin):
+    add_form = AuthTokenCreateForm
     list_display = ('digest', 'user', 'created', 'expiry',)
+    # We dont know how a custom User model looks like, but is must have a USERNAME_FIELD
+    search_fields = ['digest', 'token_key', 'user__'+get_user_model().USERNAME_FIELD]
     fields = ()
     raw_id_fields = ('user',)
+
+    def get_form(self, request, obj=None, **kwargs):
+        defaults = {}
+        if obj is None:
+            defaults['form'] = self.add_form
+        defaults.update(kwargs)
+        return super(AuthTokenAdmin, self).get_form(request, obj, **defaults)
+
+    def save_model(self, request, obj, form, change):
+        if not change:
+            self.message_user(request, "TOKEN " + form.token, messages.INFO)
+        super(AuthTokenAdmin, self).save_model(request, obj, form, change)

--- a/knox/admin.py
+++ b/knox/admin.py
@@ -1,8 +1,9 @@
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.auth import get_user_model
-from knox.settings import CONSTANTS
+
 from knox import models
+from knox.settings import CONSTANTS
 
 
 class AuthTokenCreateForm(forms.ModelForm):

--- a/knox/models.py
+++ b/knox/models.py
@@ -12,6 +12,18 @@ sha = knox_settings.SECURE_HASH_ALGORITHM
 User = settings.AUTH_USER_MODEL
 
 
+def get_expiry(expiry):
+    if expiry is not None:
+        expiry = timezone.now() + expiry
+    return expiry
+
+
+def get_digest_token(prefix=knox_settings.TOKEN_PREFIX):
+    token = prefix + crypto.create_token_string()
+    digest = crypto.hash_token(token)
+    return digest, token
+
+
 class AuthTokenManager(models.Manager):
     def create(
         self,
@@ -19,8 +31,8 @@ class AuthTokenManager(models.Manager):
         expiry=knox_settings.TOKEN_TTL,
         prefix=knox_settings.TOKEN_PREFIX
     ):
-        token = prefix + crypto.create_token_string()
-        digest = crypto.hash_token(token)
+
+        digest, token = get_digest_token(prefix)
         if expiry is not None:
             expiry = timezone.now() + expiry
         instance = super(AuthTokenManager, self).create(

--- a/knox_project/settings.py
+++ b/knox_project/settings.py
@@ -5,19 +5,23 @@ SECRET_KEY = 'gcr$j^h2@d@sd(f#-ihtv6*hg7qno$otw62^*rzcf0tk2wz&sb'
 DEBUG = True
 ALLOWED_HOSTS = []
 INSTALLED_APPS = (
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
     'rest_framework',
     'knox',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
 )
 
 ROOT_URLCONF = 'knox_project.urls'
@@ -32,6 +36,7 @@ TEMPLATES = [
                 'django.template.context_processors.debug',
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
             ],
         },
     },

--- a/knox_project/urls.py
+++ b/knox_project/urls.py
@@ -1,5 +1,5 @@
-from django.urls import include, re_path
 from django.contrib import admin
+from django.urls import include, re_path
 
 from .views import RootView
 

--- a/knox_project/urls.py
+++ b/knox_project/urls.py
@@ -1,8 +1,10 @@
 from django.urls import include, re_path
+from django.contrib import admin
 
 from .views import RootView
 
 urlpatterns = [
     re_path(r'^api/', include('knox.urls')),
     re_path(r'^api/$', RootView.as_view(), name="api-root"),
+    re_path(r'^admin/', admin.site.urls),
 ]


### PR DESCRIPTION
The current state of the Django Admin integration for adding new AuthToken is not really functional.

I created a custom  admin form for adding new tokens, that requires to specify a user and optionally a expiry date.
To get the django form save() method to work, which does internaly not use the managers create() method, but creates a AuthToken object and later calls .save() i had to extract the logic for generating the digest and token values from the AuthTokenManager.create() method to reuse it in the admin form.

The Token itself will be presented to the user using the django messaging framework ( which is a requirement for the admin anyway) after saving the AuthToken ( see attached image ) 

I also added a search filter to the AdminView to filter the list of AuthTokens for User.USERNAME_FIELD, token_key and digest value.

Finally i added the admin view dependencies to to reference project.

![image](https://github.com/jazzband/django-rest-knox/assets/8334424/f3735d80-8376-4de5-8c13-dee16d3e8856)
