### PR TITLE
Avoid importing `django.test` in main code

### DIFF
--- a/knox/settings.py
+++ b/knox/settings.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.test.signals import setting_changed
+from django.core.signals import setting_changed
 from rest_framework.settings import APISettings, api_settings
 
 USER_SETTINGS = getattr(settings, 'REST_KNOX', None)


### PR DESCRIPTION
`setting_changed` is actually from `django.core.signals`, and is re-exported from `django.test.signals`.

`django.test` takes 20-40ms to import, so not too much, but it's an easy win to avoid this import.