### PR TITLE
Migrate to ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,0 @@
-[flake8]
-max-line-length = 90
-max-complexity = 10
-exclude = *migrations*

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,0 @@
-[settings]
-combine_as_imports = true
-default_section = THIRDPARTY
-include_trailing_comma = true
-known_first_party = knox
-multi_line_output = 5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.3
     hooks:
-      - id: flake8
+      - id: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,4 @@
 repos:
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,4 @@ repos:
     rev: v0.4.3
     hooks:
       - id: ruff
+        args: [--fix]

--- a/knox/auth.py
+++ b/knox/auth.py
@@ -5,7 +5,8 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions
 from rest_framework.authentication import (
-    BaseAuthentication, get_authorization_header,
+    BaseAuthentication,
+    get_authorization_header,
 )
 
 from knox.crypto import hash_token

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,13 @@ select = [
     "C90", # Mccabe
     "E", # Pycodestyle Error
     "F", # Pyflakes
+    "I", # Isort
     "W", # Pycodestyle Warning
 ]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10
+
+[tool.ruff.lint.isort]
+combine-as-imports = true
+known-first-party = ["knox"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,6 @@ select = [
     "W", # Pycodestyle Warning
 ]
 
-[tool.ruff.lint.mccabe]
-max-complexity = 10
-
 [tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party = ["knox"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.ruff]
+exclude = ["*migrations*"]
+line-length = 90
+
+[tool.ruff.lint]
+ignore = []
+select = [
+    "C90", # Mccabe
+    "E", # Pycodestyle Error
+    "F", # Pyflakes
+    "W", # Pycodestyle Warning
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,8 @@
 [tox]
 envlist =
-    isort,
-    flake8,
     py{36,37,38,39,310}-django32,
     py{38,39,310,311,312}-django42,
     py{310,311,312}-django50,
-
-[testenv:flake8]
-deps = flake8
-changedir = {toxinidir}
-commands = flake8 knox
-
-[testenv:isort]
-deps = isort
-changedir = {toxinidir}
-commands = isort --check-only --diff \
-    knox \
-    knox_project/views.py \
-    setup.py \
-    tests
 
 [testenv]
 commands =
@@ -33,7 +17,6 @@ deps =
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     markdown>=3.0
-    isort>=5.0
     djangorestframework
     freezegun
     mkdocs
@@ -50,5 +33,5 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311, isort, flake8
+    3.11: py311
     3.12: py312


### PR DESCRIPTION
This PR proposes using [Ruff ](https://docs.astral.sh/ruff/) for linting. 

The flake8 and isort configs have been migrated initially, but further lint checks could be enabled in the future.

As this repo has pre-commit CI installed, I do not believe that linting needs to be included in the test workflow, so both flake8 and isort have been removed from the tox config. 

Currently, ruff does not allow for `multi_line_output`; the discussion around this can be found [here](https://github.com/astral-sh/ruff/issues/2600). As this only affects one import, I don't see this as too egregious of a change.