### PR TITLE
Remove EOL versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,10 @@
 repos:
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.16.0
+    hooks:
+      - id: django-upgrade
+        args: [--target-version, "4.2"]
+
   - repo: https://github.com/PyCQA/isort
     rev: 5.13.2
     hooks:

--- a/knox_project/settings.py
+++ b/knox_project/settings.py
@@ -49,7 +49,6 @@ DATABASES = {
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'
 USE_I18N = True
-USE_L10N = True  # Deprecated since django 4.0.
 USE_TZ = True
 
 STATIC_URL = '/static/'

--- a/knox_project/urls.py
+++ b/knox_project/urls.py
@@ -1,8 +1,8 @@
-from django.urls import include, re_path
+from django.urls import include, path
 
 from .views import RootView
 
 urlpatterns = [
-    re_path(r'^api/', include('knox.urls')),
-    re_path(r'^api/$', RootView.as_view(), name="api-root"),
+    path('api/', include('knox.urls')),
+    path('api/', RootView.as_view(), name="api-root"),
 ]

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     # https://packaging.python.org/en/latest/requirements.html
     python_requires='>=3.6',
     install_requires=[
-        'django>=3.2',
+        'django>=4.2',
         'djangorestframework',
     ],
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ setup(
         # Pick your license as you wish (should match "license" above)
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -67,7 +66,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=[
         'django>=4.2',
         'djangorestframework',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-django32,
     py{38,39,310,311,312}-django42,
     py{310,311,312}-django50,
 
@@ -13,7 +12,6 @@ setenv =
     DJANGO_SETTINGS_MODULE = knox_project.settings
     PIP_INDEX_URL = https://pypi.python.org/simple/
 deps =
-    django32: Django>=3.2,<3.3
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     markdown>=3.0

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,6 @@ deps =
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
This PR removes the following end-of-life versions of [Python](https://devguide.python.org/versions/) and [Django](https://jefftriplett.com/django-release-cycle/): 
- Python 3.6 - EOL: 23rd December 2021
- Python 3.7 - EOL: 27th June 2023
- Django 3.2 - EOL:  April 2024 

In addition to removing the EOL versions, the [Django upgrade pre-commit hook](https://github.com/adamchainz/django-upgrade) has also been added, and fixes are included in this PR. These changes relate to:
- The use of `USE_L10N`, which was deprecated in Django 4.0: https://github.com/adamchainz/django-upgrade?tab=readme-ov-file#use_l10n
- The use of `re_path`, which has been rewritten using the `path()` syntax added in Django 2.0: https://github.com/adamchainz/django-upgrade?tab=readme-ov-file#urls

