### PR TITLE
Remove flake8 and isort from tox config

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,8 @@
 [tox]
 envlist =
-    isort,
-    flake8,
     py{36,37,38,39,310}-django32,
     py{38,39,310,311,312}-django42,
     py{310,311,312}-django50,
-
-[testenv:flake8]
-deps = flake8
-changedir = {toxinidir}
-commands = flake8 knox
-
-[testenv:isort]
-deps = isort
-changedir = {toxinidir}
-commands = isort --check-only --diff \
-    knox \
-    knox_project/views.py \
-    setup.py \
-    tests
 
 [testenv]
 commands =
@@ -33,7 +17,6 @@ deps =
     django42: Django>=4.2,<4.3
     django50: Django>=5.0,<5.1
     markdown>=3.0
-    isort>=5.0
     djangorestframework
     freezegun
     mkdocs
@@ -50,5 +33,5 @@ python =
     3.8: py38
     3.9: py39
     3.10: py310
-    3.11: py311, isort, flake8
+    3.11: py311
     3.12: py312


### PR DESCRIPTION
Following on from the discussion in #344, this PR removes linting from the tox config to allow linting and testing to be run independently.