### PR TITLE
fix(docker): possible path bug

### DIFF
--- a/docker-run-tests.sh
+++ b/docker-run-tests.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 MOUNT_FOLDER=/app
-docker run --rm -it -v $(pwd):$MOUNT_FOLDER -w $MOUNT_FOLDER themattrix/tox
+docker run --rm -it -v "$(pwd)":"$MOUNT_FOLDER" -w "$MOUNT_FOLDER" themattrix/tox


### PR DESCRIPTION
Double quote to prevent globbing and word splitting. https://github.com/koalaman/shellcheck/wiki/SC2046