### PR TITLE
docs(changelog): bump to 5.0.0, add token warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 4.3.0
+## 5.0.0
+- Tokens created prior to this release will no longer work
 - Fix migration reverse flow, enable migrate 0
 - Various documentation fixes and improvements
 - Drop `cryptography` in favor of hashlib


### PR DESCRIPTION
I've increased the version to major, as this kind of a big change asks for one.

Fixes https://github.com/jazzband/django-rest-knox/issues/357

/cc @johnraz 