### PR TITLE
Use python3 syntax for super()

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -90,7 +90,7 @@ class LoginView(KnoxLoginView):
         serializer.is_valid(raise_exception=True)
         user = serializer.validated_data['user']
         login(request, user)
-        return super(LoginView, self).post(request, format=None)
+        return super().post(request, format=None)
 ```
 
 **urls.py:**


### PR DESCRIPTION
Came across this while trying to set the framework up. 
Not sure why but the given python2 syntax seems to error for my project citing `'super' object has no attribute 'post'`, migrating this to the python3 syntax seems to fix it.