### PR TITLE
Update knox.auth.py – Expose token renewal via request-scoped user flag

### DIFF
--- a/knox/auth.py
+++ b/knox/auth.py
@@ -90,7 +90,7 @@ class TokenAuthentication(BaseAuthentication):
         # Throttle refreshing of token to avoid db writes
         delta = (new_expiry - current_expiry).total_seconds()
         if delta > knox_settings.MIN_REFRESH_INTERVAL:
-            setattr(auth_token.user, '_knox_token_refreshed', True) # [MY LINE]
+            setattr(auth_token.user, '_knox_token_refreshed', True)
             auth_token.save(update_fields=('expiry',))
 
     def validate_user(self, auth_token):

--- a/knox/auth.py
+++ b/knox/auth.py
@@ -90,6 +90,7 @@ class TokenAuthentication(BaseAuthentication):
         # Throttle refreshing of token to avoid db writes
         delta = (new_expiry - current_expiry).total_seconds()
         if delta > knox_settings.MIN_REFRESH_INTERVAL:
+            setattr(auth_token.user, '_knox_token_refreshed', True) # [MY LINE]
             auth_token.save(update_fields=('expiry',))
 
     def validate_user(self, auth_token):


### PR DESCRIPTION
Set a temporary `_knox_token_refreshed` attribute on the authenticated user whenever `renew_token()` actually extends the token expiry.

A primary use case is cookie-based authentication, where middleware can re-issue the authentication cookie with an updated `Max-Age` to keep the browser cookie expiry synchronized with the backend token expiry. **This flag allows to easily detect if the token TTL has been refreshed.** Also, is request-scoped and has no effect for applications that do not use it.

Usage example:
```python
class SyncKnoxCookieMiddleware:

    def __init__(self, get_response):
        self.get_response = get_response

    def __call__(self, request):
        response = self.get_response(request)

        if getattr(request, '_cookie_handled_in_view', False):
            return response

        user = getattr(request, 'user', None)
        
        if user.is_authenticated and getattr(
            user, '_knox_token_refreshed', False
        ):
            token_key = request.COOKIES.get('knox_token')
            if token_key:
                # Set Cookie

        return response
```